### PR TITLE
Release 1.2.2

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,12 +1,9 @@
-sudo: required
+dist: xenial
 
-language: generic
+language: minimal
 
 env:
   DOCKSAL_VERSION: develop
-
-services:
-  - docker
 
 install:
   # Install Docksal to have a matching versions of Docker on the build host

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.8
+FROM alpine:3.9
 
 RUN apk add --no-cache \
 	bash \

--- a/tests/test.bats
+++ b/tests/test.bats
@@ -29,8 +29,6 @@ _healthcheck ()
 }
 
 # Waits for containers to become healthy
-# For reasoning why we are not using  `depends_on` `condition` see here:
-# https://github.com/docksal/docksal/issues/225#issuecomment-306604063
 _healthcheck_wait ()
 {
 	# Wait for cli to become ready by watching its health status
@@ -40,17 +38,15 @@ _healthcheck_wait ()
 	local elapsed=0
 
 	until _healthcheck "$container_name"; do
-	echo "Waiting for $container_name to become ready..."
-	sleep "$delay";
+		echo "Waiting for $container_name to become ready..."
+		sleep "$delay";
 
-	# Give the container 30s to become ready
-	elapsed=$((elapsed + delay))
-	if ((elapsed > timeout)); then
-		echo-error "$container_name heathcheck failed" \
-			"Container did not enter a healthy state within the expected amount of time." \
-			"Try ${yellow}fin restart${NC}"
-		exit 1
-	fi
+		# Give the container 30s to become ready
+		elapsed=$((elapsed + delay))
+		if ((elapsed > timeout)); then
+			echo "$container_name heathcheck failed"
+			exit 1
+		fi
 	done
 
 	return 0


### PR DESCRIPTION
- Switched to Alpine v3.9
- Switched Travis builds to Ubuntu 18.04 (xenial) minimal flavor
- Updated `_healthcheck_wait` function in tests
