### PR TITLE
Release 1.2.3

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2016-2018 Docksal
+Copyright (c) 2016-2019 Docksal
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,5 @@
--include env_make
+# Allow using a different docker binary
+DOCKER ?= docker
 
 VERSION ?= dev
 
@@ -10,38 +11,38 @@ NAME = docksal-ssh-agent
 .PHONY: build exec test push shell run start stop logs debug clean release
 
 build:
-	docker build -t ${REPO}:${VERSION} .
+	$(DOCKER) build -t ${REPO}:${VERSION} .
 
 test:
 	IMAGE=${REPO}:${VERSION} bats tests/test.bats
 
 push:
-	docker push ${REPO}:${VERSION}
+	$(DOCKER) push ${REPO}:${VERSION}
 
 exec:
-	@docker exec ${NAME} ${CMD}
+	@$(DOCKER) exec ${NAME} ${CMD}
 
 exec-it:
-	@docker exec -it ${NAME} ${CMD}
+	@$(DOCKER) exec -it ${NAME} ${CMD}
 
 shell:
 	@make exec-it -e CMD=sh
 
 run: clean
-	docker run --rm -it ${REPO}:${VERSION} sh
+	$(DOCKER) run --rm -it ${REPO}:${VERSION} sh
 
 # This is the only place where fin is used/necessary
 start:
 	IMAGE_SSH_AGENT=${REPO}:${VERSION} fin system reset ssh-agent
 
 stop:
-	docker stop ${NAME}
+	$(DOCKER) stop ${NAME}
 
 logs:
-	docker logs ${NAME}
+	$(DOCKER) logs ${NAME}
 
 logs-follow:
-	docker logs -f ${NAME}
+	$(DOCKER) logs -f ${NAME}
 
 debug: build start logs-follow
 
@@ -49,6 +50,6 @@ release:
 	@scripts/release.sh
 
 clean:
-	docker rm -vf ${NAME} || true
+	$(DOCKER) rm -vf ${NAME} || true
 
 default: build

--- a/tests/test.bats
+++ b/tests/test.bats
@@ -79,8 +79,9 @@ _healthcheck_wait ()
 
 	# Add the key to the agent
 	run fin ssh-key add ${ssh_key_name}
-	# Cleanup garbage \r from the output otherwise there won't be an exact match
-	[[ "$(echo ${output} | tr -d '\r')" == "Identity added: ${ssh_key_name} (${ssh_key_name})" ]]
+	# fin will warn about "Running in a non-interactive environment. SSH keys with passphrases cannot be used.",
+	# so not using an exact match here.
+	[[ "$(echo ${output})" =~ "Identity added: ${ssh_key_name} (${ssh_key_name})" ]]
 	unset output
 
 	# Check they key is present in the agent

--- a/tests/test.bats
+++ b/tests/test.bats
@@ -57,7 +57,9 @@ _healthcheck_wait ()
 
 @test "${NAME} container is up and using the \"${IMAGE}\" image" {
 	[[ ${SKIP} == 1 ]] && skip
-	_healthcheck_wait
+
+	run _healthcheck_wait
+	unset output
 
 	run docker ps --filter "name=${NAME}" --format "{{ .Image }}"
 	[[ "$output" =~ "${IMAGE}" ]]

--- a/tests/test.bats
+++ b/tests/test.bats
@@ -75,7 +75,7 @@ _healthcheck_wait ()
 	ssh_key_name="ssh_agent_test_id_rsa"
 	ssh_key_file="${HOME}/.ssh/${ssh_key_name}"
 	rm -f ${ssh_key_file}
-	ssh-keygen -t rsa -b 4096 -f ${ssh_key_file} -q -N ""
+	ssh-keygen -t rsa -b 4096 -f ${ssh_key_file} -q -N "" -C ""
 
 	# Add the key to the agent
 	run fin ssh-key add ${ssh_key_name}

--- a/tests/test.bats
+++ b/tests/test.bats
@@ -1,7 +1,7 @@
 #!/usr/bin/env bats
 
 # Debugging
-teardown() {
+teardown () {
 	echo
 	echo "Output:"
 	echo "================================================================"
@@ -14,14 +14,14 @@ teardown() {
 _healthcheck ()
 {
 	local health_status
-	health_status=$(docker inspect --format='{{json .State.Health.Status}}' "$1" 2>/dev/null)
+	health_status=$(${DOCKER} inspect --format='{{json .State.Health.Status}}' "$1" 2>/dev/null)
 
 	# Wait for 5s then exit with 0 if a container does not have a health status property
 	# Necessary for backward compatibility with images that do not support health checks
 	if [[ $? != 0 ]]; then
-	echo "Waiting 10s for container to start..."
-	sleep 10
-	return 0
+		echo "Waiting 10s for container to start..."
+		sleep 10
+		return 0
 	fi
 
 	# If it does, check the status
@@ -32,8 +32,8 @@ _healthcheck ()
 _healthcheck_wait ()
 {
 	# Wait for cli to become ready by watching its health status
-	local container_name="${NAME}"
-	local delay=5
+	local container_name="${1}"
+	local delay=1
 	local timeout=30
 	local elapsed=0
 
@@ -58,10 +58,12 @@ _healthcheck_wait ()
 @test "${NAME} container is up and using the \"${IMAGE}\" image" {
 	[[ ${SKIP} == 1 ]] && skip
 
-	run _healthcheck_wait
+	run _healthcheck_wait ${NAME}
 	unset output
 
-	run docker ps --filter "name=${NAME}" --format "{{ .Image }}"
+	# Using "bash -c" here to expand ${DOCKER} (in case it's more that a single word).
+	# Without bats run returns "command not found"
+	run bash -c "${DOCKER} ps --filter 'name=${NAME}' --format '{{ .Image }}'"
 	[[ "$output" =~ "${IMAGE}" ]]
 	unset output
 }


### PR DESCRIPTION
- Updated LICENSE year
- Updated _healthcheck_wait function in tests
- Allow using a different docker binary in Makefile and tests
  - Necessary for building and testing locally using VirtualBox mode: `export DOCKER='fin docker'`
- Fixed tests on Mac and Travis
