### PR TITLE
Support SSH proxy over TCP

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,3 +50,12 @@ Docker Compose
 ```bash
 docker run --rm --volumes-from=ssh-agent -it docksal/ssh-agent ssh-add -D
 ```
+
+### Running in TCP proxy mode
+
+This image supports creating a Unix socket that connects to a remote TCP socket, e.g. when connecting
+to a remote machine that exposes a Unix socket as a TCP endpoint.
+
+```bash
+docker run -d --name=ssh-agent docksal/ssh-agent ssh-proxy {host/IP} {TCP port}
+```

--- a/bin/docker-entrypoint.sh
+++ b/bin/docker-entrypoint.sh
@@ -5,15 +5,26 @@ set -e # Abort if anything fails
 # Create the temporary key storage directory
 mkdir -p ${SSH_DIR}
 
+# Clean up previous socket files
+rm -f ${SSH_AUTH_SOCK} ${SSH_AUTH_PROXY_SOCK}
+
 # Service mode
 if [[ "$1" == "ssh-agent" ]]; then
 	# Create proxy-socket for ssh-agent (to give anyone accees to the ssh-agent socket)
 	echo "Creating proxy socket..."
-	rm ${SSH_AUTH_SOCK} ${SSH_AUTH_PROXY_SOCK} || true
 	socat UNIX-LISTEN:${SSH_AUTH_PROXY_SOCK},perm=0666,fork UNIX-CONNECT:${SSH_AUTH_SOCK} &
-	echo "Launching ssh-agent..."
+
 	# Start ssh-agent
+	echo "Launching ssh-agent..."
 	exec /usr/bin/ssh-agent -a ${SSH_AUTH_SOCK} -d
+
+# Proxy mode
+elif [[ "$1" == "ssh-proxy" ]]; then
+	# Create proxy-socket for TCP target
+	tcp_target_ip="$2"
+	tcp_target_port="$3"
+	exec socat UNIX-LISTEN:${SSH_AUTH_PROXY_SOCK},perm=0666,fork TCP:${tcp_target_ip}:${tcp_target_port}
+
 # Command mode
 else
 	exec "$@"

--- a/healthcheck.sh
+++ b/healthcheck.sh
@@ -1,6 +1,7 @@
 #!/usr/bin/env bash
+set -eo pipefail
 
-netstat -nlp | grep -E "LISTENING.*${SSH_AUTH_PROXY_SOCK}" >/dev/null || exit 1
-netstat -nlp | grep -E "LISTENING.*${SSH_AUTH_SOCK}" >/dev/null || exit 1
-
-exit 0
+netstat -nlp | grep -qE "LISTENING.*${SSH_AUTH_PROXY_SOCK}"
+if [[ "$DOCKSAL_SSH_AGENT_USE_HOST" != "1" ]]; then
+	netstat -nlp | grep -qE "LISTENING.*${SSH_AUTH_SOCK}"
+fi

--- a/healthcheck.sh
+++ b/healthcheck.sh
@@ -1,7 +1,16 @@
 #!/usr/bin/env bash
 set -eo pipefail
 
-netstat -nlp | grep -qE "LISTENING.*${SSH_AUTH_PROXY_SOCK}"
-if [[ "$DOCKSAL_SSH_AGENT_USE_HOST" != "1" ]]; then
+# Get the name of the process with pid=1
+docker_cmd=$(cat /proc/1/comm)
+
+# Health checks for ssh-agent mode
+if [[ "${docker_cmd}" == "ssh-agent" ]]; then
+	netstat -nlp | grep -qE "LISTENING.*${SSH_AUTH_PROXY_SOCK}"
 	netstat -nlp | grep -qE "LISTENING.*${SSH_AUTH_SOCK}"
+fi
+
+# Health checks for ssh-proxy mode
+if [[ "${docker_cmd}" == "socat" ]]; then
+	netstat -nlp | grep -qE "LISTENING.*${SSH_AUTH_PROXY_SOCK}"
 fi


### PR DESCRIPTION
This adds support for a new `ssh-proxy` mode that instead of running an SSH agent, starts a `socat` process that creates a Unix socket that transparently proxies to a remote TCP endpoint provided as an argument.

This works in conjunction with the following MR for Docksal:
https://github.com/docksal/docksal/pull/1088

The health check uses `DOCKSAL_SSH_AGENT_USE_HOST` to determine whether to check for the built-in SSH agent or not.