### PR TITLE
Release 1.3.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,10 @@ dist: xenial
 language: minimal
 
 env:
-  DOCKSAL_VERSION: develop
+  global:
+    - DOCKSAL_VERSION=develop
+    # Explicitly disable host's SSH agent usage, as we are testing docksal-ssh-agent here
+    - DOCKSAL_SSH_AGENT_USE_HOST=0
 
 install:
   # Install Docksal to have a matching versions of Docker on the build host

--- a/README.md
+++ b/README.md
@@ -50,3 +50,12 @@ Docker Compose
 ```bash
 docker run --rm --volumes-from=ssh-agent -it docksal/ssh-agent ssh-add -D
 ```
+
+### Running in TCP proxy mode
+
+This image supports creating a Unix socket that connects to a remote TCP socket, e.g. when connecting
+to a remote machine that exposes a Unix socket as a TCP endpoint.
+
+```bash
+docker run -d --name=ssh-agent docksal/ssh-agent ssh-proxy {host/IP} {TCP port}
+```

--- a/bin/docker-entrypoint.sh
+++ b/bin/docker-entrypoint.sh
@@ -5,15 +5,26 @@ set -e # Abort if anything fails
 # Create the temporary key storage directory
 mkdir -p ${SSH_DIR}
 
+# Clean up previous socket files
+rm -f ${SSH_AUTH_SOCK} ${SSH_AUTH_PROXY_SOCK}
+
 # Service mode
 if [[ "$1" == "ssh-agent" ]]; then
 	# Create proxy-socket for ssh-agent (to give anyone accees to the ssh-agent socket)
 	echo "Creating proxy socket..."
-	rm ${SSH_AUTH_SOCK} ${SSH_AUTH_PROXY_SOCK} || true
 	socat UNIX-LISTEN:${SSH_AUTH_PROXY_SOCK},perm=0666,fork UNIX-CONNECT:${SSH_AUTH_SOCK} &
-	echo "Launching ssh-agent..."
+
 	# Start ssh-agent
+	echo "Launching ssh-agent..."
 	exec /usr/bin/ssh-agent -a ${SSH_AUTH_SOCK} -d
+
+# Proxy mode
+elif [[ "$1" == "ssh-proxy" ]]; then
+	# Create proxy-socket for TCP target
+	tcp_target_ip="$2"
+	tcp_target_port="$3"
+	exec socat UNIX-LISTEN:${SSH_AUTH_PROXY_SOCK},perm=0666,fork TCP:${tcp_target_ip}:${tcp_target_port}
+
 # Command mode
 else
 	exec "$@"

--- a/healthcheck.sh
+++ b/healthcheck.sh
@@ -1,6 +1,7 @@
 #!/usr/bin/env bash
+set -eo pipefail
 
-netstat -nlp | grep -E "LISTENING.*${SSH_AUTH_PROXY_SOCK}" >/dev/null || exit 1
-netstat -nlp | grep -E "LISTENING.*${SSH_AUTH_SOCK}" >/dev/null || exit 1
-
-exit 0
+netstat -nlp | grep -qE "LISTENING.*${SSH_AUTH_PROXY_SOCK}"
+if [[ "$DOCKSAL_SSH_AGENT_USE_HOST" != "1" ]]; then
+	netstat -nlp | grep -qE "LISTENING.*${SSH_AUTH_SOCK}"
+fi

--- a/healthcheck.sh
+++ b/healthcheck.sh
@@ -1,7 +1,16 @@
 #!/usr/bin/env bash
 set -eo pipefail
 
-netstat -nlp | grep -qE "LISTENING.*${SSH_AUTH_PROXY_SOCK}"
-if [[ "$DOCKSAL_SSH_AGENT_USE_HOST" != "1" ]]; then
+# Get the name of the process with pid=1
+docker_cmd=$(cat /proc/1/comm)
+
+# Health checks for ssh-agent mode
+if [[ "${docker_cmd}" == "ssh-agent" ]]; then
+	netstat -nlp | grep -qE "LISTENING.*${SSH_AUTH_PROXY_SOCK}"
 	netstat -nlp | grep -qE "LISTENING.*${SSH_AUTH_SOCK}"
+fi
+
+# Health checks for ssh-proxy mode
+if [[ "${docker_cmd}" == "socat" ]]; then
+	netstat -nlp | grep -qE "LISTENING.*${SSH_AUTH_PROXY_SOCK}"
 fi


### PR DESCRIPTION
- TCP proxy mode for SSH agent socket
  - Used in conjunction with `SSH_AUTH_SOCK` exposed over TCP on a host
